### PR TITLE
Use pipe separator rows for Zephyr table headers

### DIFF
--- a/feature_parsers/latest_parser.py
+++ b/feature_parsers/latest_parser.py
@@ -148,10 +148,9 @@ class ZephyrOptimizedParser:
            minimums and maximums.
         2. All rows are padded so that separators align consistently
            throughout the table.
-        3. A special header separator line uses a ``#-------#`` style
-           delimiter between the header and the rest of the rows instead of
-           the standard ``|`` separator.  This addresses the user's
-           requirement to visually distinguish the header.
+        3. A special header separator line uses standard pipe (``|``)
+           delimiters with dash fillers to keep the table readable in
+           Excel/Zephyr imports while still visually separating the header.
         4. Data rows continue to use the conventional pipe (``|``) delimiters
            with consistent spacing around cell contents.
         """
@@ -245,11 +244,9 @@ class ZephyrOptimizedParser:
 
             # Insert a header separator after the first row when there are more rows
             if row_idx == 0 and len(table_data) > 1:
-                # Build a '#-------#' style separator: a hash, then dashes sized to each column,
-                # separated by hash characters, and ending with a trailing hash.  No spaces are
-                # included to emphasise the header split.
+                # Build a pipe-based separator row so Excel/Zephyr render it cleanly.
                 dash_segments = ["-" * len(formatted_cells[col_idx]) for col_idx in range(len(formatted_cells))]
-                header_sep = "#" + "#".join(dash_segments) + "#"
+                header_sep = "| " + " | ".join(dash_segments) + " |"
                 table_lines.append(header_sep)
 
         return table_lines


### PR DESCRIPTION
### Motivation
- Improve readability for Excel/Zephyr imports by replacing the visual `#----#` header separator with a pipe-based dashed row so header separation renders cleanly without introducing visual clutter.

### Description
- Update `ZephyrOptimizedParser._format_table_with_auto_width` to build a pipe-delimited header separator (`| --- |`) instead of the previous hash-delimited style, and adjust the method docstring to describe the new behavior in `feature_parsers/latest_parser.py`.

### Testing
- No automated tests were run for this small formatting change (no test failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b633e94c88333abfe9e7e060c9a2f)